### PR TITLE
Added Darkmode toggle, fixed settings and help&support button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Modern, secure and instant video chat application built with React, TypeScript, 
 - ⚡ **Instant Rooms** - Create or join rooms quickly
 - ⏰ **Unlimited Time** - No time restrictions on calls
 - 🧪 **Camera Test** - Test your camera and microphone before joining
-- 🎨 **Modern UI** - Clean, responsive design with modern header
+ - 🎨 **Modern UI** - Clean, responsive design with modern header
+ - 🌓 **Dark Mode** - Toggle between light and dark themes (auto-detects system preference)
+ - ⚙️ **Settings Panel** - Configure appearance (theme) and upcoming media preferences
+ - ❓ **Help & Support Panel** - Built-in FAQ and resource links
 
 ## 🛠️ Tech Stack
 
@@ -108,6 +111,27 @@ src/
 - Toggle microphone on/off  
 - End call and return to homepage
 - Copy room link to share with others
+ - Use the theme toggle in the header (moon/sun icon) to switch between dark and light mode
+ - Open Settings (gear) for theme options
+ - Open Help (question mark) for FAQ and troubleshooting
+
+### Dark Mode
+### Help & Settings Panels
+The header includes dedicated buttons for quick access:
+- Help button opens an in-app modal with FAQ, troubleshooting, and external resource links.
+- Settings button opens a modal where you can change theme or reset to system preference. Media options are placeholders for upcoming releases.
+
+To extend:
+1. Add new rows in `SettingsModal` with user preferences (store in localStorage or future backend).
+2. Add more FAQ entries in `HelpModal` by appending objects or JSX blocks.
+3. Consider adding keyboard focus trapping and ESC key handling for enhanced accessibility.
+The application stores your theme preference in `localStorage` under the key `chat-real-theme` and applies it early during page load to avoid a flash of incorrect theme. If no preference is stored, the system color scheme (`prefers-color-scheme`) is used.
+
+Implementation details:
+- CSS variables defined in `index.css` under `:root` and `:root[data-theme='dark']`
+- A `ThemeProvider` (`useTheme` hook) manages state and persistence
+- `ThemeToggle` component in the header provides the UI switch
+- Accessible: the toggle button has an `aria-label` that updates per state
 
 ## 🔧 Configuration
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -131,5 +131,11 @@ export default tseslint.config(
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
     },
+  },
+  {
+    files: ['src/hooks/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    }
   }
 );

--- a/index.html
+++ b/index.html
@@ -12,6 +12,19 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <title>Chat Real - Video Chat</title>
+  <script>
+    // Early theme application to avoid flash
+    (function() {
+      try {
+        var stored = localStorage.getItem('chat-real-theme');
+        var systemPref = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        var theme = stored || systemPref;
+        document.documentElement.dataset.theme = theme;
+      } catch (e) {
+        document.documentElement.dataset.theme = 'light';
+      }
+    })();
+  </script>
 </head>
 
 <body>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,11 +2,12 @@
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--glass-solid);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(229, 231, 235, 0.8);
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid var(--glass-border);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.08), 0 1px 2px 0 rgba(0, 0, 0, 0.04);
   font-family: 'Inter', sans-serif;
+  transition: background-color .3s ease, color .3s ease, border-color .3s ease;
 }
 
 .container {
@@ -28,7 +29,7 @@
 .logo {
   font-size: 24px;
   font-weight: 700;
-  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--primary-500) 0%, #8b5cf6 100%);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -71,7 +72,7 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: #6b7280;
+  color: var(--muted);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -80,13 +81,13 @@
 
 .helpButton:hover,
 .settingsButton:hover {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--surface-alt);
+  color: var(--muted-strong);
 }
 
 .loginButton {
-  background: linear-gradient(90deg,#06b6d4,#3b82f6);
-  color: white;
+  background: var(--gradient-primary);
+  color: #fff;
 }
 
 .loginButton:hover {
@@ -110,13 +111,13 @@
   border: none;
   border-radius: 12px;
   background: transparent;
-  color: #374151;
+  color: var(--muted-strong);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .profileButton:hover {
-  background: #f3f4f6;
+  background: var(--surface-alt);
 }
 
 .userName {
@@ -142,12 +143,13 @@
   top: calc(100% + 8px);
   right: 0;
   min-width: 260px;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--surface);
+  border: 1px solid var(--divider);
   border-radius: 12px;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.15), 0 4px 6px -2px rgba(0,0,0,0.08);
   padding: 8px;
   animation: fadeIn 0.15s ease-out;
+  transition: background-color .3s ease, border-color .3s ease;
 }
 
 @keyframes fadeIn {
@@ -166,7 +168,7 @@
   align-items: center;
   gap: 12px;
   padding: 12px;
-  color: #374151;
+  color: var(--muted-strong);
 }
 
 .dropdownName {
@@ -177,12 +179,12 @@
 
 .dropdownEmail {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--muted);
 }
 
 .dropdownDivider {
   border: none;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--divider);
   margin: 4px 0;
 }
 
@@ -195,7 +197,7 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: #374151;
+  color: var(--muted-strong);
   font-size: 14px;
   text-align: left;
   cursor: pointer;
@@ -203,7 +205,7 @@
 }
 
 .dropdownItem:hover {
-  background: #f3f4f6;
+  background: var(--surface-alt);
 }
 
 /* Mobile Menu */
@@ -215,14 +217,14 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: #6b7280;
+  color: var(--muted);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .mobileMenuButton:hover {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--surface-alt);
+  color: var(--muted-strong);
 }
 
 .mobileMenu {
@@ -230,13 +232,14 @@
   top: 100%;
   left: 0;
   right: 0;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--surface);
+  border: 1px solid var(--divider);
   border-top: none;
   border-radius: 0 0 12px 12px;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.15);
   padding: 16px;
   animation: slideDown 0.2s ease-out;
+  transition: background-color .3s ease, border-color .3s ease;
 }
 
 @keyframes slideDown {
@@ -264,7 +267,7 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: #374151;
+  color: var(--muted-strong);
   font-size: 16px;
   text-align: left;
   cursor: pointer;
@@ -272,7 +275,7 @@
 }
 
 .mobileMenuItem:hover {
-  background: #f3f4f6;
+  background: var(--surface-alt);
 }
 
 .mobileUserInfo {
@@ -281,7 +284,7 @@
   gap: 12px;
   padding: 12px 16px;
   border-radius: 8px;
-  background: #f9fafb;
+  background: var(--surface-alt);
   margin-bottom: 8px;
 }
 
@@ -293,7 +296,7 @@
 
 .mobileUserEmail {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--muted);
 }
 
 /* Backdrop */

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,6 +9,9 @@ import {
   MdClose
 } from 'react-icons/md';
 import styles from './Header.module.css';
+import { ThemeToggle } from '../ThemeToggle/index.tsx';
+import { SettingsModal } from '../SettingsModal';
+import { HelpModal } from '../HelpModal';
 
 interface HeaderProps {
   onHelpClick?: () => void;
@@ -19,6 +22,8 @@ interface HeaderProps {
 export const Header = ({ onHelpClick, onSettingsClick, onLoginClick }: HeaderProps) => {
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   
   // Mock user state - later this will come from authentication
   const [isLoggedIn, setIsLoggedIn] = useState(true);
@@ -45,16 +50,14 @@ export const Header = ({ onHelpClick, onSettingsClick, onLoginClick }: HeaderPro
   };
 
   const handleSettings = () => {
-    if (onSettingsClick) {
-      onSettingsClick();
-    }
+    if (onSettingsClick) onSettingsClick();
     setShowUserMenu(false);
+    setShowSettings(true);
   };
 
   const handleHelp = () => {
-    if (onHelpClick) {
-      onHelpClick();
-    }
+    if (onHelpClick) onHelpClick();
+    setShowHelp(true);
   };
 
   return (
@@ -77,6 +80,8 @@ export const Header = ({ onHelpClick, onSettingsClick, onLoginClick }: HeaderPro
             >
               <MdHelpOutline size={20} />
             </button>
+
+            <ThemeToggle />
 
             <button 
               className={styles.settingsButton}
@@ -158,6 +163,9 @@ export const Header = ({ onHelpClick, onSettingsClick, onLoginClick }: HeaderPro
                 <MdHelpOutline size={20} />
                 Help & Support
               </button>
+              <div style={{padding:'6px 4px'}}>
+                <ThemeToggle />
+              </div>
               
               <button className={styles.mobileMenuItem} onClick={handleSettings}>
                 <MdSettings size={20} />
@@ -199,6 +207,12 @@ export const Header = ({ onHelpClick, onSettingsClick, onLoginClick }: HeaderPro
           }}
         />
       )}
+    {showSettings && (
+      <SettingsModal onClose={() => setShowSettings(false)} />
+    )}
+    {showHelp && (
+      <HelpModal onClose={() => setShowHelp(false)} />
+    )}
     </header>
   );
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,18 +1,19 @@
 import { useState } from 'react';
-import { 
-  MdAccountCircle, 
-  MdSettings, 
-  MdLogin, 
+import {
+  MdAccountCircle,
+  MdSettings,
+  MdLogin,
   MdHelpOutline,
   MdKeyboardArrowDown,
   MdMenu,
-  MdClose
+  MdClose,
 } from 'react-icons/md';
 
-import styles from './Header.module.css';
-import { ThemeToggle } from '../ThemeToggle/index.tsx';
-import { SettingsModal } from '../SettingsModal';
 import { HelpModal } from '../HelpModal';
+import { SettingsModal } from '../SettingsModal';
+import { ThemeToggle } from '../ThemeToggle/index.tsx';
+
+import styles from './Header.module.css';
 
 interface HeaderProps {
   onHelpClick?: () => void;

--- a/src/components/HelpModal/HelpModal.module.css
+++ b/src/components/HelpModal/HelpModal.module.css
@@ -1,0 +1,17 @@
+.backdrop { position: fixed; inset:0; background: rgba(0,0,0,.4); backdrop-filter: blur(4px); display:flex; align-items:flex-start; justify-content:center; padding:70px 18px 40px; z-index:4100; }
+.modal { width:100%; max-width:640px; background:var(--surface); color:var(--text); border:1px solid var(--divider); border-radius:24px; padding:34px 38px 46px; box-shadow:0 24px 50px -12px rgba(0,0,0,.38),0 0 0 1px rgba(255,255,255,.04); position:relative; animation:popIn .42s cubic-bezier(.16,.84,.44,1); }
+@keyframes popIn { from{opacity:0; transform:translateY(26px) scale(.96);} to{opacity:1; transform:translateY(0) scale(1);} }
+.closeBtn { position:absolute; top:14px; right:14px; width:42px; height:42px; border-radius:14px; border:1px solid var(--divider); background:var(--surface-alt); display:flex; align-items:center; justify-content:center; cursor:pointer; color:var(--muted-strong); transition:background-color .25s;} .closeBtn:hover{background:var(--surface-hover);} 
+.header { margin-bottom:18px; }
+.header h2 { margin:0 0 6px; font-size:26px; font-weight:600; }
+.header p { margin:0; font-size:14px; opacity:.65; }
+.faq { margin-top:8px; display:flex; flex-direction:column; gap:18px; }
+.q { font-weight:600; font-size:15px; margin:0 0 4px; }
+.a { margin:0; font-size:13px; line-height:1.55; opacity:.78; }
+.section { margin-top:28px; }
+.section h3 { margin:0 0 10px; font-size:13px; letter-spacing:.5px; text-transform:uppercase; opacity:.7; font-weight:600; }
+.links { display:flex; gap:14px; flex-wrap:wrap; }
+.linkBtn { background:var(--surface-alt); border:1px solid var(--divider); padding:10px 16px; border-radius:10px; font-size:13px; cursor:pointer; color:var(--muted-strong); transition:background-color .25s; }
+.linkBtn:hover { background:var(--surface-hover); }
+.footerNote { margin-top:34px; font-size:12px; opacity:.55; text-align:center; }
+@media (max-width:600px){ .modal{padding:28px 24px 40px; border-radius:20px;} .closeBtn{width:38px; height:38px;} }

--- a/src/components/HelpModal/index.tsx
+++ b/src/components/HelpModal/index.tsx
@@ -1,0 +1,63 @@
+import { MdClose } from 'react-icons/md';
+import styles from './HelpModal.module.css';
+
+interface HelpModalProps {
+  onClose: () => void;
+}
+
+export const HelpModal = ({ onClose }: HelpModalProps) => {
+  return (
+    <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Help and Support">
+      <div className={styles.modal}>
+        <button className={styles.closeBtn} aria-label="Close help" onClick={onClose}>
+          <MdClose size={22} />
+        </button>
+
+        <div className={styles.header}>
+          <h2>Help & Support</h2>
+          <p>Quick answers and guidance for using Chat Real.</p>
+        </div>
+
+        <div className={styles.faq}>
+          <div>
+            <p className={styles.q}>How do I create a room?</p>
+            <p className={styles.a}>On the landing page click “Create New Room”. A unique ID is generated and added to the URL – share that link.</p>
+          </div>
+          <div>
+            <p className={styles.q}>People can’t see/hear me.</p>
+            <p className={styles.a}>Check browser permission (camera & mic icon near address bar). Close other apps using your camera, then rejoin.</p>
+          </div>
+          <div>
+            <p className={styles.q}>What does dark mode change?</p>
+            <p className={styles.a}>We switch a set of CSS variables (colors, surfaces, shadows) so every themed component updates instantly.</p>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Resources</h3>
+          <div className={styles.links}>
+            <button className={styles.linkBtn} onClick={() => window.open('https://webrtc.org/get-started/','_blank')}>WebRTC Basics</button>
+            <button className={styles.linkBtn} onClick={() => window.open('https://developer.chrome.com/docs/web-platform/site-capabilities/','_blank')}>Permissions Help</button>
+            <button className={styles.linkBtn} onClick={() => window.open('https://github.com/your-username/chat-real/issues','_blank')}>Report Issue</button>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Troubleshooting</h3>
+          <div className={styles.faq}>
+            <div>
+              <p className={styles.q}>Video frozen?</p>
+              <p className={styles.a}>Try turning video off/on using controls. If it persists, refresh the page (peer connection will renegotiate).</p>
+            </div>
+            <div>
+              <p className={styles.q}>Audio echo?</p>
+              <p className={styles.a}>Use headphones and ensure only one tab is in the same room.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.footerNote}>More help coming soon · v1 help panel</div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/HelpModal/index.tsx
+++ b/src/components/HelpModal/index.tsx
@@ -1,4 +1,5 @@
 import { MdClose } from 'react-icons/md';
+
 import styles from './HelpModal.module.css';
 
 interface HelpModalProps {

--- a/src/components/Landing/Landing.module.css
+++ b/src/components/Landing/Landing.module.css
@@ -1,7 +1,8 @@
 .landing {
   min-height: 100vh;
-  background: linear-gradient(135deg, #764ba2 0%, #553C9A 100%);
+  background: linear-gradient(135deg, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
   font-family: 'Inter', sans-serif;
+  transition: background 0.35s ease;
 }
 
 .content {
@@ -10,7 +11,7 @@
   align-items: center;
   justify-content: center;
   min-height: calc(100vh - 64px);
-  color: white;
+  color: var(--text);
   text-align: center;
   padding: 28px 20px 120px; /* extra bottom padding so footer doesn't overlap actions */
   position: relative;
@@ -55,13 +56,13 @@
 }
 
 .feature {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--glass);
   padding: 20px;
   border-radius: 14px;
   backdrop-filter: blur(6px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  transition: transform 0.22s cubic-bezier(.2,.9,.2,1), box-shadow 0.22s ease;
-  box-shadow: 0 6px 18px rgba(2,6,23,0.45);
+  border: 1px solid var(--glass-border);
+  transition: transform 0.22s cubic-bezier(.2,.9,.2,1), box-shadow 0.22s ease, background-color .3s;
+  box-shadow: var(--shadow-elevated);
 }
 
 .feature:hover {
@@ -93,8 +94,8 @@
 }
 
 .primaryButton {
-  background: linear-gradient(90deg, #06b6d4, #3b82f6);
-  color: white;
+  background: var(--gradient-primary);
+  color: #fff;
   border: none;
   padding: 14px 34px;
   border-radius: 14px;
@@ -102,8 +103,8 @@
   font-size: 18px;
   font-weight: 700;
   cursor: pointer;
-  transition: transform 0.22s ease, box-shadow 0.22s ease;
-  box-shadow: 0 8px 30px rgba(59,130,246,0.14);
+  transition: transform 0.22s ease, box-shadow 0.22s ease, filter .3s;
+  box-shadow: 0 8px 30px rgba(59,130,246,0.18);
   display: inline-flex;
   align-items: center;
   gap: 12px;
@@ -127,8 +128,8 @@
 
 .secondaryButton {
   background: transparent;
-  color: white;
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  color: var(--text);
+  border: 2px solid var(--divider);
   padding: 12px 24px;
   border-radius: 8px;
   font-family: 'Inter', sans-serif;
@@ -142,17 +143,17 @@
 }
 
 .secondaryButton:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.5);
+  background: var(--surface-hover);
+  border-color: var(--muted-strong);
 }
 
 .joinRoomSection {
   margin-top: 28px;
   padding: 18px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--glass);
   border-radius: 12px;
   backdrop-filter: blur(6px);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--glass-border);
   max-width: 420px;
   width: 100%;
 }
@@ -166,29 +167,29 @@
 .joinInput {
   width: 100%;
   padding: 12px 16px;
-  border: 2px solid rgba(255, 255, 255, 0.2);
+  border: 2px solid var(--divider);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
+  background: var(--surface-alt);
+  color: var(--text);
   font-family: 'Inter', sans-serif;
   font-size: 16px;
   margin-bottom: 16px;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, background-color .3s;
 }
 
 .joinInput::placeholder {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--muted);
 }
 
 .joinInput:focus {
   outline: none;
-  border-color: rgba(255, 255, 255, 0.5);
+  border-color: var(--primary-500);
 }
 
 .joinButton {
   width: 100%;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
+  background: var(--gradient-primary);
+  color: #fff;
   border: none;
   padding: 12px 16px;
   border-radius: 8px;
@@ -200,7 +201,7 @@
 }
 
 .joinButton:hover {
-  background: rgba(255, 255, 255, 0.3);
+  filter: brightness(1.05);
 }
 
 .footer {
@@ -211,7 +212,7 @@
   text-align: center;
   font-size: 13px;
   opacity: 0.8;
-  color: rgba(255,255,255,0.9);
+  color: var(--muted-strong);
   z-index: 10;
 }
 

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
-import { 
-  MdVideoCall, 
-  MdMic, 
-  MdVideocam, 
-  MdSecurity, 
-  MdDevices, 
+import {
+  MdVideoCall,
+  MdMic,
+  MdVideocam,
+  MdSecurity,
+  MdDevices,
   MdGroup,
   MdArrowForward,
-  MdAccessTime 
+  MdAccessTime,
 } from 'react-icons/md';
 
 import { generateRoomId } from '../../utils/roomUtils';
 import { CameraTest } from '../CameraTest';
 import { Header } from '../Header';
 import { HelpModal } from '../HelpModal';
+
 import styles from './Landing.module.css';
 
 interface LandingProps {

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -12,6 +12,7 @@ import {
 import { generateRoomId } from '../../utils/roomUtils';
 import { CameraTest } from '../CameraTest';
 import { Header } from '../Header';
+import { HelpModal } from '../HelpModal';
 import styles from './Landing.module.css';
 
 interface LandingProps {
@@ -21,6 +22,7 @@ interface LandingProps {
 export const Landing = ({ onStartCall }: LandingProps) => {
   const [joinRoomId, setJoinRoomId] = useState('');
   const [showCameraTest, setShowCameraTest] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
 
   const handleCreateRoom = () => {
     const roomId = generateRoomId();
@@ -76,8 +78,7 @@ export const Landing = ({ onStartCall }: LandingProps) => {
   ];
 
   const handleHelpClick = () => {
-    // TODO: Navigate to help page or open help modal
-    console.log('Help clicked');
+    setShowHelp(true);
   };
 
   const handleSettingsClick = () => {
@@ -127,7 +128,7 @@ export const Landing = ({ onStartCall }: LandingProps) => {
         </button>
 
         <div className={styles.secondaryActions}>
-          <button className={styles.secondaryButton}>
+          <button className={styles.secondaryButton} onClick={() => setShowHelp(true)}>
             <MdMic size={20} />
             How it Works?
           </button>
@@ -167,6 +168,9 @@ export const Landing = ({ onStartCall }: LandingProps) => {
 
         {showCameraTest && (
           <CameraTest onClose={() => setShowCameraTest(false)} />
+        )}
+        {showHelp && (
+          <HelpModal onClose={() => setShowHelp(false)} />
         )}
       </div>
     </div>

--- a/src/components/SettingsModal/SettingsModal.module.css
+++ b/src/components/SettingsModal/SettingsModal.module.css
@@ -1,0 +1,152 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 80px 20px 40px;
+  z-index: 4000;
+}
+
+.modal {
+  width: 100%;
+  max-width: 540px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--divider);
+  border-radius: 20px;
+  padding: 28px 32px 36px;
+  box-shadow: 0 20px 40px -10px rgba(0,0,0,0.35), 0 0 0 1px rgba(255,255,255,0.04);
+  position: relative;
+  animation: modalIn .35s cubic-bezier(.16,.84,.44,1) forwards;
+}
+
+@keyframes modalIn {
+  from { opacity: 0; transform: translateY(18px) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.titleWrap h2 {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.titleWrap p {
+  margin: 0;
+  font-size: 14px;
+  opacity: .7;
+  line-height: 1.4;
+}
+
+.closeBtn {
+  background: var(--surface-alt);
+  border: 1px solid var(--divider);
+  color: var(--muted-strong);
+  font: inherit;
+  border-radius: 10px;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color .25s ease;
+}
+.closeBtn:hover { background: var(--surface-hover); }
+
+.section {
+  margin-top: 26px;
+}
+.section h3 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  opacity: .75;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--divider);
+}
+.row:last-child { border-bottom: none; }
+
+.rowLabel {
+  flex: 1;
+}
+.rowLabel strong { display:block; font-size:15px; margin-bottom:4px; }
+.rowLabel span { font-size:13px; opacity:.65; }
+
+.inlineControls { display: flex; align-items: center; gap: 12px; }
+
+.resetBtn {
+  background: transparent;
+  border: 1px solid var(--divider);
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--muted-strong);
+  transition: background-color .25s ease, color .25s ease;
+}
+.resetBtn:hover { background: var(--surface-alt); }
+
+.footerActions {
+  margin-top: 34px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+.saveBtn {
+  background: var(--gradient-primary);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  padding: 12px 22px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  letter-spacing: .3px;
+  box-shadow: 0 8px 24px -6px rgba(0,0,0,0.35);
+  transition: filter .3s ease;
+}
+.saveBtn:hover { filter: brightness(1.06); }
+
+.cancelBtn {
+  background: var(--surface-alt);
+  border: 1px solid var(--divider);
+  color: var(--muted-strong);
+  font-weight: 500;
+  padding: 12px 18px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color .25s ease;
+}
+.cancelBtn:hover { background: var(--surface-hover); }
+
+.themeToggleWrap { min-width: 70px; }
+
+@media (max-width: 560px) {
+  .modal { padding: 22px 22px 30px; }
+  .row { flex-direction: column; align-items: flex-start; }
+  .inlineControls { width: 100%; }
+  .footerActions { flex-direction: column-reverse; align-items: stretch; }
+  .saveBtn, .cancelBtn { width: 100%; }
+}

--- a/src/components/SettingsModal/index.tsx
+++ b/src/components/SettingsModal/index.tsx
@@ -8,10 +8,14 @@ interface SettingsModalProps {
 }
 
 export const SettingsModal = ({ onClose }: SettingsModalProps) => {
-  const { theme, setTheme } = useTheme();
+  const { setTheme } = useTheme();
 
   const resetToSystem = () => {
-    try { localStorage.removeItem('chat-real-theme'); } catch {}
+    try {
+      localStorage.removeItem('chat-real-theme');
+  } catch {
+      // ignore storage errors (private mode or quota)
+    }
     const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     setTheme(systemPref as 'light' | 'dark');
   };

--- a/src/components/SettingsModal/index.tsx
+++ b/src/components/SettingsModal/index.tsx
@@ -1,6 +1,8 @@
 import { MdClose } from 'react-icons/md';
+
 import { useTheme } from '../../hooks/useTheme';
 import { ThemeToggle } from '../ThemeToggle/index.tsx';
+
 import styles from './SettingsModal.module.css';
 
 interface SettingsModalProps {

--- a/src/components/SettingsModal/index.tsx
+++ b/src/components/SettingsModal/index.tsx
@@ -1,0 +1,77 @@
+import { MdClose } from 'react-icons/md';
+import { useTheme } from '../../hooks/useTheme';
+import { ThemeToggle } from '../ThemeToggle/index.tsx';
+import styles from './SettingsModal.module.css';
+
+interface SettingsModalProps {
+  onClose: () => void;
+}
+
+export const SettingsModal = ({ onClose }: SettingsModalProps) => {
+  const { theme, setTheme } = useTheme();
+
+  const resetToSystem = () => {
+    try { localStorage.removeItem('chat-real-theme'); } catch {}
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    setTheme(systemPref as 'light' | 'dark');
+  };
+
+  return (
+    <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Settings">
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <div className={styles.titleWrap}>
+            <h2>Settings</h2>
+            <p>Customize your experience.</p>
+          </div>
+          <button className={styles.closeBtn} aria-label="Close settings" onClick={onClose}>
+            <MdClose size={22} />
+          </button>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Appearance</h3>
+          <div className={styles.row}>
+            <div className={styles.rowLabel}>
+              <strong>Color Theme</strong>
+              <span>Switch between light and dark appearance.</span>
+            </div>
+            <div className={styles.inlineControls}>
+              <div className={styles.themeToggleWrap}>
+                <ThemeToggle />
+              </div>
+              <button className={styles.resetBtn} onClick={resetToSystem}>System</button>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Media</h3>
+          <div className={styles.row}>
+            <div className={styles.rowLabel}>
+              <strong>Autostart Camera (coming soon)</strong>
+              <span>Automatically enable camera when joining a room.</span>
+            </div>
+            <div className={styles.inlineControls}>
+              <span style={{fontSize:13, opacity:.55}}>Planned</span>
+            </div>
+          </div>
+          <div className={styles.row}>
+            <div className={styles.rowLabel}>
+              <strong>Noise Suppression (coming soon)</strong>
+              <span>Improve microphone clarity.</span>
+            </div>
+            <div className={styles.inlineControls}>
+              <span style={{fontSize:13, opacity:.55}}>Planned</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.footerActions}>
+          <button className={styles.cancelBtn} onClick={onClose}>Close</button>
+          <button className={styles.saveBtn} onClick={onClose}>Done</button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ThemeToggle/index.ts
+++ b/src/components/ThemeToggle/index.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -1,5 +1,7 @@
 import { MdDarkMode, MdLightMode } from 'react-icons/md';
+
 import { useTheme } from '../../hooks/useTheme';
+
 import styles from './themeToggle.module.css';
 
 export const ThemeToggle = () => {

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -1,0 +1,25 @@
+import { MdDarkMode, MdLightMode } from 'react-icons/md';
+import { useTheme } from '../../hooks/useTheme';
+import styles from './themeToggle.module.css';
+
+export const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className={styles.toggle}
+    >
+      <span className={styles.iconWrapper} data-active={isDark}>
+        <MdDarkMode size={18} />
+      </span>
+      <span className={styles.iconWrapper} data-active={!isDark}>
+        <MdLightMode size={18} />
+      </span>
+      <span className={styles.knob} data-theme={theme} />
+    </button>
+  );
+};

--- a/src/components/ThemeToggle/themeToggle.module.css
+++ b/src/components/ThemeToggle/themeToggle.module.css
@@ -1,0 +1,52 @@
+.toggle {
+  --toggle-height: 34px;
+  --toggle-width: 70px;
+  position: relative;
+  width: var(--toggle-width);
+  height: var(--toggle-height);
+  border-radius: calc(var(--toggle-height) / 2);
+  border: 1px solid var(--divider);
+  background: var(--surface-alt);
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px;
+  cursor: pointer;
+  overflow: hidden;
+  transition: background-color .35s ease, border-color .35s ease;
+}
+
+.toggle:hover {
+  background: var(--surface-hover);
+}
+
+.iconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  transition: color .35s ease, transform .45s cubic-bezier(.68,-0.55,.27,1.55);
+}
+
+.iconWrapper[data-active='true'] {
+  color: var(--primary-500);
+  transform: scale(1.15) rotate(8deg);
+}
+
+.knob {
+  position: absolute;
+  top: 3px;
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.15), 0 4px 10px rgba(0,0,0,0.08);
+  transition: transform .45s cubic-bezier(.68,-0.55,.27,1.55), background-color .35s ease;
+  left: 4px;
+}
+
+.knob[data-theme='dark'] {
+  transform: translateX(34px);
+}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'chat-real-theme';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return prefersDark ? 'dark' : 'light';
+  } catch {
+    return 'light';
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* ignore */
+    }
+  }, [theme]);
+
+  const setTheme = (t: Theme) => setThemeState(t);
+  const toggleTheme = () => setThemeState((prev: Theme) => prev === 'dark' ? 'light' : 'dark');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,14 +1,6 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
 export type Theme = 'light' | 'dark';
-
-interface ThemeContextValue {
-  theme: Theme;
-  toggleTheme: () => void;
-  setTheme: (t: Theme) => void;
-}
-
-const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 const STORAGE_KEY = 'chat-real-theme';
 
@@ -23,6 +15,14 @@ function getInitialTheme(): Theme {
     return 'light';
   }
 }
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(getInitialTheme);

--- a/src/index.css
+++ b/src/index.css
@@ -4,15 +4,54 @@
   padding: 0;
 }
 
+/* Light theme (default) */
 :root {
-  --bg-100: #764ba2;
-  --bg-200: #553C9A;
-  --glass: rgba(255,255,255,0.06);
-  --muted: rgba(255,255,255,0.6);
-  --text: #e6eef8;
+  --color-bg-gradient-start: #764ba2;
+  --color-bg-gradient-end: #553C9A;
+  --bg-100: var(--color-bg-gradient-start);
+  --bg-200: var(--color-bg-gradient-end);
+  --glass: rgba(255,255,255,0.55);
+  --glass-solid: rgba(255,255,255,0.95);
+  --glass-border: rgba(229,231,235,0.8);
+  --muted: rgba(55,65,81,0.7);
+  --muted-strong: #374151;
+  --text: #1f2937;
+  --text-inverse: #f1f5f9;
+  --surface: #ffffff;
+  --surface-alt: #f3f4f6;
+  --surface-hover: #f1f5f9;
+  --divider: #e5e7eb;
   --primary-500: #3b82f6;
   --accent-500: #06b6d4;
   --success-500: #10b981;
+  --danger-500: #ef4444;
+  --shadow-elevated: 0 6px 18px rgba(2,6,23,0.18);
+  --gradient-primary: linear-gradient(90deg, var(--accent-500), var(--primary-500));
+}
+
+/* Dark theme overrides */
+:root[data-theme='dark'] {
+  --color-bg-gradient-start: #0f172a; /* slate-900 */
+  --color-bg-gradient-end: #1e293b;   /* slate-800 */
+  --bg-100: var(--color-bg-gradient-start);
+  --bg-200: var(--color-bg-gradient-end);
+  --glass: rgba(255,255,255,0.06);
+  --glass-solid: rgba(30,41,59,0.85);
+  --glass-border: rgba(255,255,255,0.08);
+  --muted: rgba(255,255,255,0.6);
+  --muted-strong: #e2e8f0;
+  --text: #e6eef8;
+  --text-inverse: #0f172a;
+  --surface: #1e293b;
+  --surface-alt: #24324a;
+  --surface-hover: #2d3d57;
+  --divider: rgba(255,255,255,0.12);
+  --primary-500: #3b82f6;
+  --accent-500: #06b6d4;
+  --success-500: #10b981;
+  --danger-500: #ef4444;
+  --shadow-elevated: 0 6px 18px rgba(0,0,0,0.55);
+  --gradient-primary: linear-gradient(90deg, var(--accent-500), var(--primary-500));
 }
 
 html, body {
@@ -26,7 +65,7 @@ html, body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(135deg, #764ba2 0%, #553C9A 100%);
+  background: linear-gradient(135deg, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
   color: var(--text);
   overflow: auto;
   scrollbar-width: none; 
@@ -44,4 +83,25 @@ body::-webkit-scrollbar {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  transition: background-color .25s ease, color .25s ease;
+}
+
+/* Utility surfaces */
+.surface {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.surface-alt {
+  background: var(--surface-alt);
+}
+
+.elevated {
+  box-shadow: var(--shadow-elevated);
+}
+
+/* Scrollbar theming (only visible if forced to show) */
+body[data-theme='dark']::-webkit-scrollbar-thumb,
+:root[data-theme='dark'] body::-webkit-scrollbar-thumb {
+  background: var(--surface-hover);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './hooks/useTheme'
 
-createRoot(document.getElementById('root')!).render(
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
-)
+  )
+}


### PR DESCRIPTION
## Changes Made

This PR introduces several key UI and UX improvements to the **chat-real** app: #10 

**Dark Mode System**

* Implemented CSS variable architecture for light and dark themes.
* Early theme application script to prevent flash of incorrect theme on load.
* User preference persisted in `localStorage` with system fallback (`chat-real-theme`).

**Theme Toggle**

* Reusable animated toggle component added to the header and Settings modal.
* Smooth transitions for colors and surfaces.

**Settings Panel (Modal) - Fixed**

* Opens from gear icon in header.
* Contains theme toggle and “System” reset button to clear stored preferences.
* Placeholder rows added for future media preferences.

**Help & Support Panel (Modal) - Fixed**

* Opens from header Help icon and Landing page “How it Works?” button.
* Contains FAQ, troubleshooting hints, and resource links.

**Landing & Header Integration**

* Header updated to host ThemeToggle and modal triggers.
* Landing page wired to open Help modal.

These changes enhance usability, accessibility, and theming consistency across the app.

## Screenshots 
![cr1](https://github.com/user-attachments/assets/429d2ee1-0a1b-42ab-b18c-ed0cc6c526f4)
![cr2](https://github.com/user-attachments/assets/5236d7d5-99d7-4e43-9114-ccc7d98715e3)
![cr3](https://github.com/user-attachments/assets/cead62ed-9ea1-4f9d-9ef0-bbd937d00b6b)
![cr4](https://github.com/user-attachments/assets/bccf9fcf-417f-47ba-b0f3-beb28fafe70a)

