### PR TITLE
 prevent memory leaks by pausing video elements during cleanup

### DIFF
--- a/src/hooks/useVideoChat.ts
+++ b/src/hooks/useVideoChat.ts
@@ -22,9 +22,13 @@ export const useVideoChat = (roomId: string) => {
     
     // Clean video elements first
     if (localVideoRef.current) {
+      // Pause video and remove srcObject
+      localVideoRef.current.pause();
       localVideoRef.current.srcObject = null;
     }
     if (remoteVideoRef.current) {
+      // Pause video and remove srcObject
+      remoteVideoRef.current.pause();
       remoteVideoRef.current.srcObject = null;
     }
 


### PR DESCRIPTION
## 📋 Description
Brief description of the changes in this PR.
Added calls to pause the local and remote video elements before clearing their video sources during cleanup. This ensures that video playback is properly stopped, preventing potential memory leaks and improving resource management when the video chat component is unmounted or the call ends.



## 🔗 Related Issue
Fixes #27 
Closes #27 

